### PR TITLE
Some more complete instructions for some of the suggestions

### DIFF
--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -383,7 +383,7 @@ def check_modules():
                     "Recommendation: Replace eslintrc by new flat config.")
             elif "eslint.config" not in str(sorted(module_directory_path.rglob("*"))):
                 module["issues"].append(
-                    "Recommendation: No ESLint configuration was found. ESLint is very helpful, it is worth using it even for small projects.")
+                    "Recommendation: No ESLint configuration was found. ESLint is very helpful, it is worth using it even for small projects (basic instructions: <https://github.com/MagicMirrorOrg/MagicMirror-3rd-Party-Modules/issues/11>).")
             else:
                 # Check if ESLint is in the dependencies or devDependencies
                 package_json = Path(f"{module_directory_path}/package.json")

--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -383,7 +383,7 @@ def check_modules():
                     "Recommendation: Replace eslintrc by new flat config.")
             elif "eslint.config" not in str(sorted(module_directory_path.rglob("*"))):
                 module["issues"].append(
-                    "Recommendation: No ESLint configuration was found. ESLint is very helpful, it is worth using it even for small projects (basic instructions: <https://github.com/MagicMirrorOrg/MagicMirror-3rd-Party-Modules/issues/11>).")
+                    "Recommendation: No ESLint configuration was found. ESLint is very helpful, it is worth using it even for small projects (basic instructions: <https://github.com/MagicMirrorOrg/MagicMirror-3rd-Party-Modules/blob/main/guides/eslint.md>).")
             else:
                 # Check if ESLint is in the dependencies or devDependencies
                 package_json = Path(f"{module_directory_path}/package.json")

--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -370,7 +370,7 @@ def check_modules():
                                         f"Recommendation: `{file_path.name}`: Use official file extension `.yaml` instead of `.yml` (<https://yaml.org/faq.html>).")
 
             if "LICENSE" not in str(sorted(module_directory_path.rglob("*"))):
-                module["issues"].append("Warning: No LICENSE file.")
+                module["issues"].append("Warning: No LICENSE file (example: <https://github.com/KristjanESPERANTO/MMM-WebSpeechTTS/blob/main/LICENSE.md>).")
 
             if "CHANGELOG" not in str(sorted(module_directory_path.rglob("*"))):
                 module["issues"].append("Recommendation: There is no CHANGELOG file. It is recommended to add one (example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/CHANGELOG.md>).")

--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -52,27 +52,27 @@ def check_modules():
             "category": "Typo"
         },
         'require("request")': {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Deprecated",
         },
         "require('request')": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Deprecated",
         },
         'require("request-promise")': {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Deprecated",
         },
         "require('request-promise')": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Deprecated",
         },
         'require("native-request")': {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Deprecated",
         },
         "require('native-request')": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Deprecated",
         },
         'require("http")': {
@@ -92,31 +92,31 @@ def check_modules():
             "category": "Recommendation",
         },
         "'node-fetch'": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         '"node-fetch"': {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         'require("fetch")': {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         "require('fetch')": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         "axios": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         '"needle"': {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         "'needle'": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         "omxplayer": {
@@ -125,7 +125,7 @@ def check_modules():
             "source": "https://github.com/popcornmix/omxplayer",
         },
         "XMLHttpRequest": {
-            "name": "Replace it with built-in fetch.",
+            "name": "Replace it with built-in fetch (docs: <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch>; example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/node_helper.js>).",
             "category": "Recommendation",
         },
         "uses: actions/checkout@v2": {

--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -376,7 +376,7 @@ def check_modules():
                 module["issues"].append("Recommendation: There is no CHANGELOG file. It is recommended to add one (example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/CHANGELOG.md>).")
 
             if "CODE_OF_CONDUCT" not in str(sorted(module_directory_path.rglob("*"))):
-                module["issues"].append("Recommendation: There is no CODE_OF_CONDUCT file. It is recommended to add one.")
+                module["issues"].append("Recommendation: There is no CODE_OF_CONDUCT file. It is recommended to add one (example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/CODE_OF_CONDUCT.md>).")
 
             if "eslintrc" in str(sorted(module_directory_path.rglob("*"))):
                 module["issues"].append(

--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -373,7 +373,7 @@ def check_modules():
                 module["issues"].append("Warning: No LICENSE file.")
 
             if "CHANGELOG" not in str(sorted(module_directory_path.rglob("*"))):
-                module["issues"].append("Recommendation: There is no CHANGELOG file. It is recommended to add one.")
+                module["issues"].append("Recommendation: There is no CHANGELOG file. It is recommended to add one (example: <https://github.com/KristjanESPERANTO/MMM-ApothekenNotdienst/blob/main/CHANGELOG.md>).")
 
             if "CODE_OF_CONDUCT" not in str(sorted(module_directory_path.rglob("*"))):
                 module["issues"].append("Recommendation: There is no CODE_OF_CONDUCT file. It is recommended to add one.")


### PR DESCRIPTION
I added some examples and docs to help point maintainers in the right direction to make changes.

I wanted to point to a good example `package.json` file, but I couldn't find where in the script those suggestions are generated.  E.g.:

`package.json issue: No repository field.`
`There are no keywords in 'package.json'. We would use them as tags on the module list page.`
`There is no package.json. We need this file to gather information about the module for the module list page.`