### PR TITLE
Search for "Updating" before complaining there are no update instruct…

### DIFF
--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -342,12 +342,18 @@ def check_modules():
                                     )
 
                             if file_path.name.startswith("README") and file_path.parent == module_directory_path:
-                                # Search for "update" or "Update" in README
+                                # Search for "update", "Update", "updating", or "Updating" in README
                                 found_update_string = search_in_file(
                                     file_path, "Update")
                                 if not found_update_string:
                                     found_update_string = search_in_file(
                                         file_path, "update")
+                                if not found_update_string:
+                                    found_update_string = search_in_file(
+                                        file_path, "updating")
+                                if not found_update_string:
+                                    found_update_string = search_in_file(
+                                        file_path, "Updating")
                                 if not found_update_string:
                                     module["issues"].append(
                                         "Recommendation: The README seems not to have an update instruction (the word 'update' is missing). Please add one."


### PR DESCRIPTION
…ions

See, e.g., https://modules.magicmirror.builders/result.html#MMM-Pinfo-by-SalekurPolas, which has instructions for "updating," but the module check reports there are none.

Also, given that the word "update" could mean a lot of different things (I've seen modules that have that word but no actual updating instructions), would we be better off searching for "git pull" instead of "update"?