### PR TITLE
use env var GITHUB_TOKEN for api calls (if set)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Based on the original list, we automatically create a website with filter functi
 
 ### How do I get my module presented in the new list?
 
-Add your module to [the original list in the wiki](https://github.com/MagicMirrorOrg/MagicMirror/wiki/3rd-party-modules). Twice a day the new list will be updated based on the original list.
+Add your module to [the original list in the wiki](https://github.com/MagicMirrorOrg/MagicMirror/wiki/3rd-party-modules). Once a day the new list will be updated based on the original list.
 
 ### How do I get my module presented perfectly in the new list?
 


### PR DESCRIPTION
This is a draft PR which we discussed [in the forum](https://forum.magicmirror.builders/post/126496).

I'm not really sure that it worked with auth for all repos so please review the [job log](https://gitlab.com/khassel/mm-container/-/jobs/10051370532).

The result looks good so far, it is published [here](https://develop-modules.magicmirror.builders/). The [MMM-HusqvarnaAutomower](https://github.com/ASteinsdoerfer/MMM-HusqvarnaAutomower) repo has now an image and the correct license.

Job needed 18min. compared to 11:30 before (which is still good).