### PR TITLE
ci: add container build

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,0 +1,36 @@
+name: "Container Build"
+
+on:
+  workflow_dispatch: # needed for manually running this workflow
+  schedule:
+    - cron: "30 5 * * *" # sadly there is no TZ support here
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout code:
+      - uses: actions/checkout@v3
+      # create json file with credentials for github container registry:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # ugly workaround for converting content of $GITHUB_REPOSITORY (= `MagicMirrorOrg/MagicMirror-3rd-Party-Modules`)
+      # to lowercase which is needed for using as image name
+      - name: downcase GITHUB_REPOSITORY
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
+      # build container image with kaniko:
+      - uses: int128/kaniko-action@v1
+        with:
+          file: container/Dockerfile
+          push: true
+          tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }}
+          labels: GITREF=${{ github.sha }}
+          build-args: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,23 @@
+FROM nikolaik/python-nodejs:latest as builder
+
+WORKDIR /workspace
+
+COPY . .
+
+ARG GITHUB_TOKEN
+RUN set -e; \
+    git config --global --add safe.directory /workspace; \
+    git log -1; \
+    export GITHUB_TOKEN="${GITHUB_TOKEN}"; \
+    npm clean-install; \
+    npm run all;
+
+FROM nginxinc/nginx-unprivileged:alpine-slim
+LABEL maintainer="MagicMirrorOrg"
+
+COPY container/default.conf /etc/nginx/conf.d/
+COPY container/nginx.conf /etc/nginx/
+
+COPY --from=builder /workspace/docs /usr/share/nginx/docs/
+
+EXPOSE 8080

--- a/container/default.conf
+++ b/container/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    access_log  /var/log/nginx/access.log  main;
+
+    location / {
+        root   /usr/share/nginx/docs;
+        index  index.html index.htm;
+    }
+
+    error_page  404              /404.html;
+
+}

--- a/container/nginx.conf
+++ b/container/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$http_x_forwarded_for - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" $remote_addr';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -30,7 +30,8 @@
     "modules/",
     "modules_temp/",
     "docs/**",
-    "eslint-config-DEBUG.json"
+    "eslint-config-DEBUG.json",
+    "container/"
   ],
   "dictionaries": ["node"]
 }


### PR DESCRIPTION
This is a draft PR for creating the container image in this repo.

We have to discuss if we want to move the build from gitlab into this repo.

I created an image on my fork which works:
- image: `docker pull ghcr.io/khassel/magicmirror-3rd-party-modules:main`
- [job log](https://github.com/khassel/MagicMirror-3rd-Party-Modules/actions/runs/15077598728/job/42388380052)

I'm not really convinced of github actions but it would be a cleaner setup to do the build here.

Disadvantages (so far):
- github actions cron has still no timezone support