### PR TITLE
change schedule time of container build workflow

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -3,7 +3,7 @@ name: "Container Build"
 on:
   workflow_dispatch: # needed for manually running this workflow
   schedule:
-    - cron: "30 5 * * *" # sadly there is no TZ support here
+    - cron: "15 3 * * *" # sadly there is no TZ support here
 
 permissions:
   contents: read


### PR DESCRIPTION
Logged times inside 3rd-party-app:

- current build with gitlab: Last Update: 21.5.2025, 05:43:15
- new build here: Last Update: 21.5.2025, 07:55:08

For avoiding changes here we should move the scheduled task so everything is ready at 06:00:00.